### PR TITLE
Updated import module on SymPy

### DIFF
--- a/QuickTour.ipynb
+++ b/QuickTour.ipynb
@@ -807,7 +807,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "%load_ext sympyprinting\n",
+      "%load_ext sympy.interactive.ipythonprinting\n",
       "from __future__ import division\n",
       "from sympy import *\n",
       "x, y = symbols(\"x y\")"


### PR DESCRIPTION
This gets rid of a warning on the latest SymPy version bundled with EPD.
