### PR TITLE
Adapted to Python 3

### DIFF
--- a/Version Control.ipynb
+++ b/Version Control.ipynb
@@ -255,6 +255,7 @@
     {
      "cell_type": "code",
      "collapsed": false,
+    "input": [
     "import hashlib\n",
     "\n",
     "# Our first commit\n",

--- a/Version Control.ipynb
+++ b/Version Control.ipynb
@@ -255,14 +255,13 @@
     {
      "cell_type": "code",
      "collapsed": false,
-     "input": [
-      "import sha\n",
-      "\n",
-      "# Our first commit\n",
-      "data1 = 'This is the start of my paper2.'\n",
-      "meta1 = 'date: 1/1/12'\n",
-      "hash1 = sha.sha(data1 + meta1).hexdigest()\n",
-      "print 'Hash:', hash1"
+    "import hashlib\n",
+    "\n",
+    "# Our first commit\n",
+    "data1 = b'This is the start of my paper2.'\n",
+    "meta1 = b'date: 1/1/12'\n",
+    "hash1 = hashlib.sha1(data1+meta1).hexdigest().encode()\n",
+    "print('Hash:', hash1)"
      ],
      "language": "python",
      "metadata": {},
@@ -281,12 +280,12 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "# Our second commit, linked to the first\n",
-      "data2 = 'Some more text in my paper...'\n",
-      "meta2 = 'date: 1/2/12'\n",
-      "# Note we add the parent hash here!\n",
-      "hash2 = sha.sha(data2 + meta2 + hash1).hexdigest()\n",
-      "print 'Hash:', hash2"
+     "# Our second commit, linked to the first\n",
+     "data2 = b'Some more text in my paper...'\n",
+     "meta2 = b'date: 1/2/12'\n",
+     "# Note we add the parent hash here!\n",
+     "hash2 = hashlib.sha1(data2 + meta2 + hash1).hexdigest().encode()\n",
+     "print('Hash:', hash2)"
      ],
      "language": "python",
      "metadata": {},

--- a/Version Control.ipynb
+++ b/Version Control.ipynb
@@ -271,7 +271,7 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "Hash: 7bb695b77966e27cfaebfa59e27a0b91f1d33813\n"
+        "Hash: b'7bb695b77966e27cfaebfa59e27a0b91f1d33813'\n"
        ]
       }
      ],
@@ -295,7 +295,7 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "Hash: 543da8bac9f643ba5611897b192a16dea42d2ab7\n"
+        "Hash: b'543da8bac9f643ba5611897b192a16dea42d2ab7'\n"
        ]
       }
      ],


### PR DESCRIPTION
I've adapted the notebook to Python 3. It requires the typical parenthesis to print but also importing `hashlib` instead of `sha`. It only affects a couple of cells.
